### PR TITLE
Add health check endpoint to API

### DIFF
--- a/api-processing/main.py
+++ b/api-processing/main.py
@@ -59,6 +59,10 @@ servicebus_queue = servicebus_client.get_queue_sender(servicebus_queue)
 def get_openapi_spec():
     return app.openapi()
 
+@app.get("/health", include_in_schema=False)
+def health_check():
+    return JSONResponse(status_code=200, content={"status": "healthy"})
+
 @app.post(
     "/api/process",
     response_class=JSONResponse,

--- a/terraform/staging/api-processing.tfvars
+++ b/terraform/staging/api-processing.tfvars
@@ -1,1 +1,1 @@
-API_PROCESSING_IMAGE="ghcr.io/tkubica12/gh-copilot-demo/gh-copilot-demo-api-processing:b3f9453f726a53322bec900cf803492b4d90d087"
+API_PROCESSING_IMAGE="ghcr.io/tkubica12/gh-copilot-demo/gh-copilot-demo-api-processing:c8efa64907438b8de1e63c0696c9e4a7d4c85ca9"


### PR DESCRIPTION
This pull request adds a new health check endpoint to the API in the `api-processing/main.py` file. The most important change is the addition of the `health_check` function to verify the service's health status.

* [`api-processing/main.py`](diffhunk://#diff-91ddeffc36be847b79c476ae90b72d54e401e4e20cb2e5b350be5ee0da9ed895R62-R65): Added a new `health_check` function to provide a health status endpoint at `/health`, returning a JSON response with a status code of 200 and a content of `{"status": "healthy"}`.
