### PR TITLE
Add issue triage workflow-agent demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The workshop follows one connected engineering story:
 
 ## Token-efficiency benchmark highlight
 
-The course now includes a measured token-efficiency lab. The headline lecture table is in [Chapter 05](docs/workshop/05-token-efficiency.md), with detailed results in [`tools/copilot-token-lab/suite-example-analysis.md`](tools/copilot-token-lab/suite-example-analysis.md) and rerun instructions in [`tools/copilot-token-lab/README.md`](tools/copilot-token-lab/README.md).
+The course now includes a measured token-efficiency lab. The headline lecture table is in [Chapter 05](docs/workshop/05-token-efficiency.md), with detailed results in [`tools/copilot-token-lab/suite-example-analysis.md`](tools/copilot-token-lab/suite-example-analysis.md) and rerun instructions in [`tools/copilot-token-lab/README.md`](tools/copilot-token-lab/README.md). Use the companion article [Token saving in GitHub Copilot](https://tomaskubica.cz/en/2026/token-saving-cz/) for the longer narrative and keep the repo chapter focused on measured workshop evidence.
 
 ## Supporting material
 
@@ -42,5 +42,6 @@ The course now includes a measured token-efficiency lab. The headline lecture ta
 - [`docs/enterprise_demo_flow.md`](docs/enterprise_demo_flow.md) is the concise presenter flow.
 - [`.github/prompts`](.github/prompts) and [`.github/skills`](.github/skills) contain reusable Copilot starts and local capabilities.
 - [`tools/copilot-token-lab`](tools/copilot-token-lab/README.md) contains the token measurement side project.
+- [Agent skills and central management](https://tomaskubica.cz/en/2026/agent-skills-centralni-sprava/) complements the local skills chapter with central operating-model guidance.
 
 This repository is for demonstrations and learning, not for production use.

--- a/docs/ImplementationLog.md
+++ b/docs/ImplementationLog.md
@@ -1,5 +1,14 @@
 # Implementation Log
 
+## 2026-06-10 - Added issue-triage workflow-agent demo
+
+Expanded the workflow-agent workshop material so GitHub Agentic Workflows show concrete issue triage, not only scheduled reports or pull request governance follow-up.
+
+### Decisions
+- Added `examples\gh-aw\issue-triage.md` with label and comment safe outputs so the first workflow-agent demo performs bounded, visible writes.
+- Updated the workflow-agent chapter to present issue triage, daily reports, and PR governance as a maturity ladder.
+- Linked the token-efficiency and centrally managed skills articles from the workshop docs instead of duplicating their broader narrative inside the repo.
+
 ## 2026-04-26 – Expanded token lab with scaled context and cost units
 
 Extended the token-efficiency lab so the measured suite covers scaled `AGENTS.md` versus dynamic skills, Caveman-inspired response terseness, and relative model cost units.
@@ -197,4 +206,3 @@ Removed reliance on `RUN_INTEGRATION_TESTS` environment flag. Integration tests 
 
 ### 2025-08-31 – Integration test skip timing fix
 Adjusted integration test modules to load `.env` before evaluating `@pytest.mark.skipif` so that environment variables defined only in the service `.env` file are recognized during collection. Previously the skip condition ran before the autouse fixture loaded `.env`, causing false skips.
-

--- a/docs/workshop/02-skills-and-mcp.md
+++ b/docs/workshop/02-skills-and-mcp.md
@@ -20,6 +20,8 @@ Good short explanation:
 - skills excel when you want something lightweight, local, and easy to package with the repository
 - MCP excels when you want live tools, external systems, or centrally managed enterprise integrations
 
+For a deeper discussion of how to manage skills centrally instead of copying one-off skill folders everywhere, point readers to the companion article: [Agent skills and central management](https://tomaskubica.cz/en/2026/agent-skills-centralni-sprava/). Keep this chapter focused on the hands-on repo examples; use the article for operating-model discussion.
+
 ## 3.2 See skills in action
 
 Open:

--- a/docs/workshop/05-token-efficiency.md
+++ b/docs/workshop/05-token-efficiency.md
@@ -6,6 +6,8 @@
 
 This chapter turns token efficiency into a measurable engineering practice. It summarizes the lecture guidance and links to the repeatable Copilot CLI measurement lab.
 
+For the narrative version of the same guidance, use the companion article [Token saving in GitHub Copilot](https://tomaskubica.cz/en/2026/token-saving-cz/). This chapter intentionally stays focused on workshop evidence, prompts, and lab artifacts so the article can carry the broader explanation without duplicating it here.
+
 ## Measured benchmark summary
 
 These results come from a real local run of the reusable suite in `..\..\tools\copilot-token-lab`. Treat them as lab evidence and rerun the suite for current client, model, and repository state. Use **weighted units** as the headline metric when pricing weights are available because input, cached input, and output tokens can have different prices.

--- a/docs/workshop/07-workflow-agents.md
+++ b/docs/workshop/07-workflow-agents.md
@@ -23,8 +23,24 @@ Traditional GitHub Actions workflows are deterministic YAML pipelines: build, te
 Open:
 
 - `examples\gh-aw\README.md`
+- `examples\gh-aw\issue-triage.md`
 - `examples\gh-aw\daily-maintainer-report.md`
 - `examples\gh-aw\governance-after-pr.md`
+
+### Issue triage
+
+This is the most concrete and lowest-risk workflow-agent demo. The workflow runs when an issue is opened or reopened, classifies the issue with a small allowlist of labels, and posts a short comment about feasibility, clarity, missing details, and the recommended next step.
+
+This maps directly to the latest GitHub Agentic Workflows examples: issue triage is useful because it is judgment-driven, repository-specific, and hard to capture as deterministic YAML. It is also safe to demonstrate because the only writes are `add-labels` and `add-comment`; the agent cannot close the issue, assign users, merge code, or create an implementation PR.
+
+Good live-demo issue comment shape:
+
+```text
+Classification: documentation
+Feasibility: clear enough for a small docs PR
+Missing details: none
+Recommendation: assign to Copilot coding agent or handle as a quick maintainer PR
+```
 
 ### Daily maintainer report
 
@@ -34,7 +50,15 @@ This workflow runs on a weekday schedule. It asks the agent to analyze recent pu
 
 This workflow triggers on pull request events. It asks the agent to summarize the PR intent, highlight unresolved review concerns, note failing CI checks and security findings, and recommend whether the next step should be a coding-agent task, a workflow-agent task, or human review. Again, the only permitted write action is creating a governance issue.
 
-Both examples show the pattern: the agent brings judgment and context synthesis, while deterministic pipelines remain the source of truth for builds, tests, and releases.
+These examples show the pattern: the agent brings judgment and context synthesis, while deterministic pipelines remain the source of truth for builds, tests, and releases.
+
+The three examples form a clear maturity ladder:
+
+| Stage | Example | Safe outputs |
+| --- | --- | --- |
+| Start | Issue triage | add allowed labels and one comment |
+| Scale | Daily maintainer report | create a bounded report issue |
+| Govern | Governance after PR | create a bounded follow-up issue |
 
 ## 7.3 Try this
 
@@ -54,6 +78,8 @@ Draft a variant of this workflow that creates a governance issue only when pull 
 
 - workflow agents are a natural next step after coding agents
 - they are useful for scheduled or event-driven repository automation
+- issue triage is the fastest way to show visible, useful agentic workflow output
+- safe outputs make the demo credible because writes are allowlisted and bounded
 - human approval and deterministic pipelines still matter
 
 ---

--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -20,4 +20,6 @@ This folder contains the detailed lecture flow for the GitHub Copilot Demo works
 
 - [Enterprise demo flow](../enterprise_demo_flow.md) for presenter notes.
 - [Token lab](../../tools/copilot-token-lab/README.md) for repeatable token-efficiency measurements.
+- [Token saving article](https://tomaskubica.cz/en/2026/token-saving-cz/) for a narrative explanation of the token-efficiency chapter.
+- [Central skills management article](https://tomaskubica.cz/en/2026/agent-skills-centralni-sprava/) for operating-model guidance beyond the local skill examples.
 - [Implementation log](../ImplementationLog.md) for documentation and architecture decisions.

--- a/examples/gh-aw/README.md
+++ b/examples/gh-aw/README.md
@@ -23,14 +23,16 @@ For this workshop, they help tell the story that agentic delivery does not stop 
 ## Suggested presenter flow
 
 1. show coding agents and PR review
-2. show security findings and governance expectations
-3. show a `gh-aw` workflow that summarizes repository state or PR follow-up
-4. emphasize human review and guardrails
+2. show issue triage as the lowest-risk write workflow: labels plus a recommendation comment
+3. show security findings and governance expectations
+4. show a `gh-aw` workflow that summarizes repository state or PR follow-up
+5. emphasize human review and guardrails
 
 ## Example files
 
 - `daily-maintainer-report.md`
 - `governance-after-pr.md`
+- `issue-triage.md`
 
 ## Practical note
 
@@ -50,3 +52,7 @@ gh aw compile .github/workflows/my-workflow.md
 ```
 
 For real usage, always review permissions, safe outputs, and security guidance carefully.
+
+## Demo-ready issue triage pattern
+
+The `issue-triage.md` example mirrors GitHub's current Agentic Workflows guidance: start with small, reviewable writes before enabling agents to create code changes. The workflow can add only allowed labels and one explanatory comment. That makes it a strong first live demo because the audience can immediately see classification, feasibility assessment, and recommended next action without risking repository state.

--- a/examples/gh-aw/issue-triage.md
+++ b/examples/gh-aw/issue-triage.md
@@ -1,0 +1,38 @@
+---
+on:
+  issue:
+    types: [opened, reopened]
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: read
+tools:
+  github:
+    toolsets: [issues, labels]
+safe-outputs:
+  add-labels:
+    allowed: [bug, enhancement, documentation, question, "help wanted", "good first issue"]
+    max: 2
+  add-comment: {}
+---
+## Issue Triage
+
+Analyze the triggering issue and help maintainers decide what should happen next.
+
+## What to do
+
+1. Classify the issue by adding one or two allowed labels.
+2. Add a short maintainer-facing comment that includes:
+   - why the label or labels were selected
+   - whether the issue is clear enough for an agent or human to start
+   - any missing acceptance criteria, reproduction details, screenshots, logs, or scope decisions
+   - a recommendation: coding agent, workflow agent, human review, or close/merge with an existing issue
+
+## Guardrails
+
+- Do not close issues.
+- Do not assign users.
+- Do not create implementation pull requests from triage.
+- If the issue is ambiguous, label it `question` and ask for the smallest missing detail.
+- If the issue is actionable and low risk, mention that it is a candidate for assigning to Copilot coding agent.
+- Keep the comment concise and useful; avoid generic "thanks for reporting" filler.


### PR DESCRIPTION
## Summary
- add an issue triage GitHub Agentic Workflows example with label/comment safe outputs
- update the workflow-agent chapter to make triage the first demo in the maturity ladder
- link the token-saving and central-skills articles from the workshop docs instead of duplicating their long-form content

## Demo artifacts
- Supports #69
- Issue #69 already has labels and a triage recommendation comment for live demonstration

## Notes
- `gh aw compile` and `gh aw compile --help` hung without output in this local environment, so the new workflow source follows the current GitHub Agentic Workflows issue triage example pattern and remains stored as an inactive demo artifact under `examples\gh-aw`.